### PR TITLE
Fix SCP client could not find SFTP binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Linux version 3.14.77 (jenkins@ci-server) (gcc version 5.2.0 (OpenWrt GCC 5.2.0 
 1. Create and transfer backups of all MTD partitions:
 ```
 ./stock4230w ssh '$HOST sh' <mtd-backup.sh
-./stock4230w scp '$HOST:/tmp/lanchon/mtd-backup.tar .'
+./stock4230w scp -O '$HOST:/tmp/lanchon/mtd-backup.tar .'
 ./stock4230w ssh '$HOST "rm /tmp/lanchon/mtd-backup.tar"'
 ```
 2. Create and transfer backups of all UBI volumes:
 ```
 ./stock4230w ssh '$HOST sh' <ubi-backup.sh
-./stock4230w scp '$HOST:/tmp/lanchon/ubi-backup.tar .'
+./stock4230w scp -O '$HOST:/tmp/lanchon/ubi-backup.tar .'
 ./stock4230w ssh '$HOST "rm /tmp/lanchon/ubi-backup.tar"'
 ```
 - You might need these backups down the road, so store them.
@@ -52,7 +52,7 @@ Make sure you have backups of the stock firmware (see previous section); each de
 
 1. Install the initramfs recovery image:
 ```
-./stock4230w scp 'openwrt-[...]-askey_rt4230w-rev6-initramfs-uImage $HOST:/tmp/recovery.bin'
+./stock4230w scp -O 'openwrt-[...]-askey_rt4230w-rev6-initramfs-uImage $HOST:/tmp/recovery.bin'
 ./stock4230w ssh '$HOST sh' <install-recovery.sh
 ```
 - Note that the router has two copies of the stock OS. Depending on which one is currently running, the install script might need to install the recovery image in an area that will be erased
@@ -78,7 +78,7 @@ ssh root@192.168.1.1 'ubirmvol /dev/ubi0 -N rootfs_data && ubimkvol /dev/ubi0 -N
 6. Reboot the router in normal mode and reconnect to it if necessary.
 7. Write the recovery image to the UBI volume with:
 ```
-scp openwrt-[...]-askey_rt4230w-rev6-initramfs-uImage root@192.168.1.1:/tmp/recovery.bin
+scp -O openwrt-[...]-askey_rt4230w-rev6-initramfs-uImage root@192.168.1.1:/tmp/recovery.bin
 ssh root@192.168.1.1 'ubiupdatevol /dev/ubi0_9 /tmp/recovery.bin && rm /tmp/recovery.bin'
 ```
 8. Restore the router configuration if applicable.
@@ -129,7 +129,7 @@ There is usually no reason to upgrade the recovery image. This is provided for c
 1. [Download](https://firmware-selector.openwrt.org/?target=ipq806x%2Fgeneric&id=askey_rt4230w-rev6) the OpenWrt initramfs (kernel) image for this router.
 2. Pop up a terminal and write the recovery image (replace 192.168.1.1 with the address of your router):
 ```
-scp openwrt-[...]-askey_rt4230w-rev6-initramfs-uImage root@192.168.1.1:/tmp/recovery.bin
+scp -O openwrt-[...]-askey_rt4230w-rev6-initramfs-uImage root@192.168.1.1:/tmp/recovery.bin
 ssh root@192.168.1.1 'ubiupdatevol /dev/ubi0_9 /tmp/recovery.bin && rm /tmp/recovery.bin'
 ```
 


### PR DESCRIPTION
The OpenWRT dropbear SSH server does not support SFTP protocol. Newer versions of SCP client will use SFTP by default unless adding a `-O` flag. I have updated the command to include this change. Tested on real RAC2V1K hardware to confirm my updated scp command is working properly.

Source: https://blog.lancitou.net/scp-command-couldnt-find-sftp-server/ 